### PR TITLE
Center profile picture on mobile view

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -620,4 +620,7 @@ nav {
   width: 360px;
   padding: 10px;
 }
+.dropdown-menus {
+  justify-self: center;
+}
 }


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
FIX

* Where should the reviewer start?
CSS @MAX 900 just added a small justify-self center to fix the mobile view.
* What functionalities do these changes effect? Why were these changes made? What was the motivation behind these changes?
center our users data when clicking on profile picture drop down
* What outside features or research did you use to implement this fix?
na
* How should this be tested?
open on mobile sim in dev tools and verify you can click and view all user info
<br>

***

#### Please review considerations below:

- [x] Follows Turing Style Guidelines

- [x] Changes generate no new warnings or errors

- [x] Checked code for and corrected any spelling errors

- [x] README has been updated(if applicable)
